### PR TITLE
docs: Fix a few typos

### DIFF
--- a/simpledb/simpledb.py
+++ b/simpledb/simpledb.py
@@ -19,7 +19,7 @@ QUERY_OPERATORS = {
     # attr__eq = None, attr__noteq = None, and every(), respectively.
     'eq': '=',              # equals
     'noteq': '!=',          # not equals
-    'gt': '>',              # greather than
+    'gt': '>',              # greater than
     'gte': '>=',            # greater than or equals
     'lt': '<',              # less than
     'lte': '<=',            # less than or equals
@@ -134,7 +134,7 @@ class Request(object):
 
     def get_normalized_parameters(self):
         """
-        Returns a list constisting of all the parameters required in the
+        Returns a list consisting of all the parameters required in the
         signature in the proper order.
 
         """


### PR DESCRIPTION
There are small typos in:
- simpledb/simpledb.py

Fixes:
- Should read `greater` rather than `greather`.
- Should read `consisting` rather than `constisting`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md